### PR TITLE
fix: handle trading type change for non-standalone widget

### DIFF
--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/trading-widget/src/trading-widget/components/widget/widget.hooks.ts
+++ b/packages/trading-widget/src/trading-widget/components/widget/widget.hooks.ts
@@ -38,9 +38,19 @@ export const useWidget = () => {
   }
 
   useEffect(() => {
-    onTradingTypeChange(standalone ? type : 'deposit')
+    if (!standalone) {
+      onTradingTypeChange('deposit')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poolConfig.address, standalone])
+
+  useEffect(() => {
+    if (standalone) {
+      onTradingTypeChange(type)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [poolConfig.address, standalone, type])
+
   return {
     type,
     onTabChange,


### PR DESCRIPTION
non-standalone widget should not trigger `onTradingTypeChange` with `deposit` value on `type` change effect