### PR TITLE
fix: handle deposit slippage issue when received value exceeds send v…

### DIFF
--- a/.github/workflows/trading-widget-checks.yml
+++ b/.github/workflows/trading-widget-checks.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/trading-widget-publish.yml
+++ b/.github/workflows/trading-widget-publish.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
           scope: '@dhedge'

--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/trading-widget/src/core-kit/hooks/trading/deposit/use-deposit-slippage.test.ts
+++ b/packages/trading-widget/src/core-kit/hooks/trading/deposit/use-deposit-slippage.test.ts
@@ -59,7 +59,7 @@ describe('useDepositSlippage', () => {
       receiveAssetValue: receiveAssetInputValue,
     })
     expect(updateSettingsMock).toHaveBeenCalledTimes(1)
-    expect(updateSettingsMock).toHaveBeenCalledWith({ minSlippage: 2.12 })
+    expect(updateSettingsMock).toHaveBeenCalledWith({ minSlippage: 0 })
     act(() => rerender())
     expect(updateSettingsMock).toHaveBeenCalledTimes(2)
     expect(updateSettingsMock).toHaveBeenLastCalledWith({ minSlippage: 1.13 })

--- a/packages/trading-widget/src/core-kit/hooks/trading/deposit/use-deposit-slippage.ts
+++ b/packages/trading-widget/src/core-kit/hooks/trading/deposit/use-deposit-slippage.ts
@@ -21,7 +21,9 @@ export const useDepositSlippage = (receiveAssetInputValue: string) => {
 
   useEffect(() => {
     if (isDeposit) {
-      updateSettings({ minSlippage: Math.abs(priceDiffDebounced) })
+      const minSlippage =
+        priceDiffDebounced < 0 ? Math.abs(priceDiffDebounced) : 0
+      updateSettings({ minSlippage })
     }
   }, [updateSettings, isDeposit, priceDiffDebounced])
 }


### PR DESCRIPTION
https://trello.com/c/cKFCYELC/4306-deposit-slippage-issue-toros

Apply 0% slippage when the received value exceeds the sent value.

![image](https://github.com/dhedge/ui-kit/assets/49659185/7c00f9ff-7456-406e-8a17-6ed28dfc2046)
