### PR TITLE
fix: package.json main/module/typings fields

### DIFF
--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "main": "index.js",
   "module": "index.cjs",

--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.5",
   "type": "module",
   "main": "index.js",
-  "module": "index.cjs",
+  "module": "index.mjs",
   "typings": "index.d.ts",
   "peerDependencies": {
     "@tanstack/react-query": "^5.28.4",

--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -2,9 +2,9 @@
   "name": "@dhedge/trading-widget",
   "version": "1.2.4",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "typings": "dist/index.d.ts",
+  "main": "index.js",
+  "module": "index.cjs",
+  "typings": "index.d.ts",
   "peerDependencies": {
     "@tanstack/react-query": "^5.28.4",
     "react": ">=18.2.0",


### PR DESCRIPTION
This fixes related issue

(node:17661) [DEP0151] DeprecationWarning: Package /node_modules/@dhedge/trading-widget/ has a "main" field set to "dist/index.js", excluding the full filename and extension to the resolved file at "index.js", imported from /build/server/pages/_app.js.
 Automatic extension resolution of the "main" field is deprecated for ES modules.
(Use `node --trace-deprecation ...` to show where the warning was created)
