### PR TITLE
fix: display correct assets when withdrawing from vaults with Synthet…

### DIFF
--- a/packages/trading-widget/src/core-kit/const/synthetix.ts
+++ b/packages/trading-widget/src/core-kit/const/synthetix.ts
@@ -15,6 +15,17 @@ export const DHEDGE_SYNTHETIX_V3_VAULT_ADDRESSES: Address[] = [
   '0xe9b5260d99d283ff887859c569baf8ad1bd12aac', // Synthetix ETH Yield Arbitrum
 ]
 
+// Should include symbols for all vaults from DHEDGE_SYNTHETIX_V3_VAULT_ADDRESSES
+export const SYNTHETIX_V3_VAULTS_WITHDRAW_ASSET_SYMBOL_MAP: Record<
+  string,
+  string
+> = {
+  '0xc1e02884af4a283ca25ab63c45360d220d69da52': 'USDC',
+  '0xc3198eb5102fb3335c0e911ef1da4bc07e403dd1': 'USDC',
+  '0xddd6b1f34e12c0230ab23cbd4514560b24438514': 'ARB',
+  '0xe9b5260d99d283ff887859c569baf8ad1bd12aac': 'WETH',
+}
+
 export const SYNTHETIX_V3_POSITION_DEBT_ARGUMENTS: Record<string, string[]> = {
   '0xc1e02884af4a283ca25ab63c45360d220d69da52': [
     '170141183460469231731687303715884105982', // Synthetix USDC Yield Base ID

--- a/packages/trading-widget/src/core-kit/hooks/pool/use-pool-composition-with-fraction.ts
+++ b/packages/trading-widget/src/core-kit/hooks/pool/use-pool-composition-with-fraction.ts
@@ -40,8 +40,8 @@ export const formatPoolComposition = ({
       const isSynthetixAsset = isSynthetixV3Asset(token.tokenAddress)
       return {
         ...token,
-        tokenName: isSynthetixAsset ? 'USDC' : token.tokenName,
-        asset: isSynthetixAsset ? { iconSymbols: ['USDC'] } : token.asset,
+        tokenName: isSynthetixAsset ? 'Synthetix V3' : token.tokenName,
+        asset: isSynthetixAsset ? { iconSymbols: ['snxv3'] } : token.asset,
       }
     })
     .reduce<PoolComposition[]>((acc, asset) => {

--- a/packages/trading-widget/src/examples/simple-example.tsx
+++ b/packages/trading-widget/src/examples/simple-example.tsx
@@ -4,7 +4,7 @@ import type { FC, PropsWithChildren } from 'react'
 
 /** Replace by commented imports while using example */
 import { TradingPanelProvider } from 'core-kit'
-import { base } from 'core-kit/const'
+import { arbitrum, base } from 'core-kit/const'
 import { WagmiProvider } from 'core-kit/providers/wagmi-provider'
 import type { PoolConfig, TradingPanelContextConfig } from 'core-kit/types'
 import { TradingWidget } from 'trading-widget/components'
@@ -23,9 +23,23 @@ const SYNTHETIX_BASE: PoolConfig = {
   usePoolLogicDeposit: true,
 }
 
+const SYNTHETIX_ARBITRUM: PoolConfig = {
+  chainId: arbitrum.id,
+  symbol: 'sARBy',
+  address: '0xddd6b1f34e12c0230ab23cbd4514560b24438514',
+  depositParams: {
+    customTokens: [],
+  },
+  withdrawParams: {
+    customTokens: [],
+  },
+  usePoolLogicDeposit: true,
+}
+
 const SIMPLE_INITIAL_STATE: TradingPanelContextConfig['initialState'] = {
   poolConfigMap: {
     [SYNTHETIX_BASE.address]: SYNTHETIX_BASE,
+    [SYNTHETIX_ARBITRUM.address]: SYNTHETIX_ARBITRUM,
   },
   poolAddress: SYNTHETIX_BASE.address,
 }

--- a/packages/trading-widget/src/trading-widget/components/widget/widget-input/asset-composition-table/asset-composition-table.hooks.ts
+++ b/packages/trading-widget/src/trading-widget/components/widget/widget-input/asset-composition-table/asset-composition-table.hooks.ts
@@ -28,5 +28,5 @@ export const useAssetCompositionTable = () => {
       amount !== '0',
   )
 
-  return { poolComposition, chainId, showUnitWithdrawalTip }
+  return { poolComposition, chainId, showUnitWithdrawalTip, address }
 }

--- a/packages/trading-widget/src/trading-widget/components/widget/widget-input/asset-composition-table/asset-composition-table.tsx
+++ b/packages/trading-widget/src/trading-widget/components/widget/widget-input/asset-composition-table/asset-composition-table.tsx
@@ -4,28 +4,25 @@ import classNames from 'classnames'
 import {
   FLATMONEY_COLLATERAL_SYMBOL_MAP,
   FLAT_MONEY_UNIT_LINK,
+  SYNTHETIX_V3_VAULTS_WITHDRAW_ASSET_SYMBOL_MAP,
 } from 'core-kit/const'
 import {
   getFlatMonetUnitSymbol,
   isFlatMoneyLeveragedRethAsset,
+  isSynthetixV3Asset,
 } from 'core-kit/utils'
-import {
-  Skeleton,
-  TokenBadge,
-  TokenIcon,
-} from 'trading-widget/components/common'
+import { Skeleton, TokenBadge } from 'trading-widget/components/common'
 
 import type { AssetCompositionTableProps } from './asset-composition-table.hooks'
 import { useAssetCompositionTable } from './asset-composition-table.hooks'
-import { useTranslationContext } from '../../../../providers/translation-provider'
+import { WithdrawExplanationTip } from './withdraw-explanation-tip'
 
 export const AssetCompositionTable = ({
   className,
   showFraction = true,
   iconSize,
 }: AssetCompositionTableProps) => {
-  const t = useTranslationContext()
-  const { poolComposition, chainId, showUnitWithdrawalTip } =
+  const { poolComposition, chainId, showUnitWithdrawalTip, address } =
     useAssetCompositionTable()
 
   return (
@@ -41,6 +38,8 @@ export const AssetCompositionTable = ({
                 ({ fraction, fractionUsd, tokenName, asset, tokenAddress }) => {
                   const isLeveragedRethAsset =
                     isFlatMoneyLeveragedRethAsset(tokenAddress)
+                  const isSynthetixAsset = isSynthetixV3Asset(tokenAddress)
+
                   return (
                     <tr key={tokenName}>
                       <td
@@ -56,17 +55,20 @@ export const AssetCompositionTable = ({
                           size={iconSize}
                         />
                         {isLeveragedRethAsset && (
-                          <div className="dtw-flex dtw-gap-1 dtw-items-center dtw-text-xs dtw-text-[color:var(--panel-secondary-content-color)]">
-                            {t.as}{' '}
-                            <TokenIcon
-                              symbols={[
-                                FLATMONEY_COLLATERAL_SYMBOL_MAP[chainId] ??
-                                  'reth',
-                              ]}
-                              size="xs"
-                            />{' '}
-                            {FLATMONEY_COLLATERAL_SYMBOL_MAP[chainId] ?? 'rETH'}
-                          </div>
+                          <WithdrawExplanationTip
+                            symbol={
+                              FLATMONEY_COLLATERAL_SYMBOL_MAP[chainId] ?? 'rETH'
+                            }
+                          />
+                        )}
+                        {isSynthetixAsset && (
+                          <WithdrawExplanationTip
+                            symbol={
+                              SYNTHETIX_V3_VAULTS_WITHDRAW_ASSET_SYMBOL_MAP[
+                                address
+                              ] ?? 'Synthetix V3'
+                            }
+                          />
                         )}
                       </td>
                       {showFraction && (

--- a/packages/trading-widget/src/trading-widget/components/widget/widget-input/asset-composition-table/withdraw-explanation-tip.tsx
+++ b/packages/trading-widget/src/trading-widget/components/widget/widget-input/asset-composition-table/withdraw-explanation-tip.tsx
@@ -1,0 +1,15 @@
+import type { FC } from 'react'
+
+import { TokenIcon } from 'trading-widget/components/common'
+
+import { useTranslationContext } from 'trading-widget/providers/translation-provider'
+
+export const WithdrawExplanationTip: FC<{ symbol: string }> = ({ symbol }) => {
+  const t = useTranslationContext()
+
+  return (
+    <div className="dtw-flex dtw-gap-1 dtw-items-center dtw-text-xs dtw-text-[color:var(--panel-secondary-content-color)]">
+      {t.as} <TokenIcon symbols={[symbol]} size="xs" /> {symbol}
+    </div>
+  )
+}


### PR DESCRIPTION
…ix V3 position

<img width="534" alt="Screenshot 2024-08-27 at 16 17 18" src="https://github.com/user-attachments/assets/ee00053f-ffee-4413-a92e-850c758c14b8">
<img width="531" alt="Screenshot 2024-08-27 at 16 17 24" src="https://github.com/user-attachments/assets/f2a76aab-612e-4dc5-848d-4dd7237f4cd4">

