### PR TITLE
fix: hide deposit receive amount diff when it is positive

### DIFF
--- a/packages/trading-widget/src/trading-widget/components/widget/widget-input/widget-input.hooks.ts
+++ b/packages/trading-widget/src/trading-widget/components/widget/widget-input/widget-input.hooks.ts
@@ -48,9 +48,9 @@ export const useWidgetInput = ({
       maximumFractionDigits: getConventionalTokenPriceDecimals(amount),
     })
     if (tradingPriceDiff) {
-      return `${amountInUsd} (${tradingPriceDiff}% ${
-        type === THEME_TYPE.ERROR ? '\u{26A0}' : ''
-      })`
+      return `${amountInUsd} (${
+        tradingPriceDiff > 0 ? '+' : ''
+      }${tradingPriceDiff}% ${type === THEME_TYPE.ERROR ? '\u{26A0}' : ''})`
     }
     return amountInUsd
   }, [assetInput, assetPrice, tradingPriceDiff, displayCalculatedValue, type])


### PR DESCRIPTION
Added `+` to positive price diff


![telegram-cloud-photo-size-2-5408872802750159579-x](https://github.com/user-attachments/assets/09585519-cbdb-45e2-bbd4-222d8e5dd61e)