### PR TITLE
fix: increase DEFAULT_NO_SWAP_MIN_DEPOSIT_AMOUNT_GAP

### DIFF
--- a/packages/trading-widget/src/core-kit/const/default-data.ts
+++ b/packages/trading-widget/src/core-kit/const/default-data.ts
@@ -30,7 +30,7 @@ export const DEFAULT_DEPOSIT_METHOD: DepositMethodName = 'deposit'
 
 export const DEFAULT_WITHDRAW_SLIPPAGE = 3 // %
 export const DEFAULT_DEPOSIT_SLIPPAGE = 0 // %
-export const DEFAULT_NO_SWAP_MIN_DEPOSIT_AMOUNT_GAP = 0.1 // %
+export const DEFAULT_NO_SWAP_MIN_DEPOSIT_AMOUNT_GAP = 0.2 // %
 export const DEFAULT_SWAP_TRANSACTION_SLIPPAGE = 0.3 // %
 
 export const DEFAULT_WITHDRAW_SLIPPAGE_SCALE = [

--- a/packages/trading-widget/src/core-kit/hooks/trading/deposit-v2/use-min-vault-tokens-received-amount.test.ts
+++ b/packages/trading-widget/src/core-kit/hooks/trading/deposit-v2/use-min-vault-tokens-received-amount.test.ts
@@ -83,7 +83,7 @@ describe('useMinVaultTokensReceivedAmount', () => {
     const { result, rerender } = renderHook(() =>
       useMinVaultTokensReceivedAmount(),
     )
-    expect(result.current).toBe('1998')
+    expect(result.current).toBe('1996')
 
     vi.mocked(useTradingPanelSettings).mockReturnValueOnce([
       { slippage: 0 },


### PR DESCRIPTION
It will affect only no swaps depositing and is used to protect users from receiving too small amount of vault tokens 