### PR TITLE
feat/update-withdraw-stepper-styling

### DIFF
--- a/packages/trading-widget/src/trading-widget/components/withdraw/stepper/withdraw-stepper.hooks.tsx
+++ b/packages/trading-widget/src/trading-widget/components/withdraw/stepper/withdraw-stepper.hooks.tsx
@@ -58,7 +58,12 @@ export const useWithdrawStepper = () => {
       index: COMPLETE_STEP_INDEX,
       description: (
         <>
-          {t.completeWithdrawDescription.replace('{assetSymbol}', assetSymbol)}{' '}
+          <span>
+            {t.completeWithdrawDescription.replace(
+              '{assetSymbol}',
+              assetSymbol,
+            )}
+          </span>
           <TooltipIcon
             text={t.completeWithdrawTooltip}
             iconClassName="!dtw-inline"

--- a/packages/trading-widget/src/trading-widget/components/withdraw/stepper/withdraw-stepper.tsx
+++ b/packages/trading-widget/src/trading-widget/components/withdraw/stepper/withdraw-stepper.tsx
@@ -1,5 +1,8 @@
-import { ArrowRightIcon, CheckIcon } from '@heroicons/react/20/solid'
-import { ClockIcon } from '@heroicons/react/24/outline'
+import {
+  ArrowRightCircleIcon,
+  CheckCircleIcon,
+  LockClosedIcon,
+} from '@heroicons/react/24/outline'
 import classNames from 'classnames'
 import type { FC, PropsWithChildren } from 'react'
 
@@ -15,32 +18,67 @@ export const WithdrawStepper: FC<PropsWithChildren> = ({
   }
 
   return (
-    <div className="dtw-mt-1">
-      {steps.map((step) => {
-        const completed = step.index < activeStepIndex
+    <div className="dtw-mt-1 dtw-grid dtw-gap-1 dtw-grid-cols-[auto_1fr]">
+      {steps.map((step, index) => {
+        const isCompleted = step.index < activeStepIndex
         const isActive = step.index === activeStepIndex
+        const isLast = index === steps.length - 1
+        const Icon = isCompleted
+          ? CheckCircleIcon
+          : isActive
+            ? ArrowRightCircleIcon
+            : LockClosedIcon
         return (
-          <div
-            key={step.index}
-            className="dtw-flex dtw-flex-col dtw-gap-0.5 dtw-text-[length:var(--panel-input-label-font-size,var(--panel-font-size-sm))] dtw-text-[color:var(--panel-content-color)]"
-          >
+          <>
             <div
-              className={classNames('dtw-flex dtw-gap-1', {
-                'dtw-text-[color:var(--panel-secondary-content-color)]':
-                  completed,
-              })}
+              className={classNames(
+                'dtw-grid dtw-grid-cols-1 dtw-h-full dtw-gap-0.5',
+                {
+                  'dtw-text-themeGreen': isCompleted,
+                  'dtw-text-[color:var(--panel-secondary-content-color)]':
+                    !isCompleted && !isActive,
+                  'dtw-grid-rows-[auto_1fr]': !isLast,
+                },
+              )}
             >
-              {completed ? (
-                <CheckIcon className="dtw-w-4 dtw-text-themeGreen" />
-              ) : isActive ? (
-                <ArrowRightIcon className="dtw-w-4" />
-              ) : (
-                <ClockIcon className="dtw-w-4" />
-              )}{' '}
-              {step.description}
-            </div>{' '}
-            {isActive && <div className="dtw-my-0.5">{ActionButton}</div>}
-          </div>
+              <Icon className={classNames('dtw-w-4')} />
+              {!isLast && (
+                <div className="dtw-h-full dtw-min-h-1">
+                  <div
+                    className={classNames(
+                      'dtw-w-[1px] dtw-h-full dtw-m-auto dtw-bg-[color:var(--panel-secondary-content-color)]',
+                    )}
+                  />
+                </div>
+              )}
+            </div>
+            <div
+              key={step.index}
+              className="dtw-flex dtw-flex-col dtw-gap-0.5 dtw-text-[length:var(--panel-input-label-font-size,var(--panel-font-size-sm))] dtw-text-[color:var(--panel-content-color)]"
+            >
+              <div
+                className={classNames(
+                  'dtw-flex dtw-gap-1 dtw-leading-none dtw-items-center',
+                  {
+                    'dtw-text-[color:var(--panel-secondary-content-color)]':
+                      !isCompleted && !isActive,
+                  },
+                )}
+              >
+                {step.description}
+              </div>
+              {isActive && (
+                <div
+                  className={classNames({
+                    'dtw-my-1': !isLast,
+                    'dtw-mt-1': isLast,
+                  })}
+                >
+                  {ActionButton}
+                </div>
+              )}
+            </div>
+          </>
         )
       })}
     </div>


### PR DESCRIPTION
Updates WithdrawStepper styling:

<img width="491" alt="Screenshot 2024-11-05 at 00 25 43" src="https://github.com/user-attachments/assets/0375241b-96eb-4e90-9b09-94d8cc3f662a">


<img width="484" alt="Screenshot 2024-11-05 at 00 25 58" src="https://github.com/user-attachments/assets/08b01255-6031-446b-aa9d-466d601da744">


<img width="487" alt="Screenshot 2024-11-05 at 00 26 59" src="https://github.com/user-attachments/assets/c53023c3-8483-41bb-88bf-133728482032">
