### PR TITLE
feat: add isAllAssetsWithdrawOptionDefault to widget config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ UI configuration provider. Manages params to configure custom styling, component
 ##### params
 
 > | name                               | type                                                           | default value                | description                                                                                                                                        |
-> | ---------------------------------- | -------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | ---------------------------------- | -------------------------------------------------------------- | ---------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------|
 > | `isGeoBlocked`                     | `boolean`                                                      | `false`                      | Restricts depositing action button and conditionally renders GeoBlockAlert component                                                               |
 > | `isSanctioned`                     | `boolean`                                                      | `false`                      | Restricts depositing action button and conditionally renders SanctionedAlert component                                                             |
 > | `depositQuoteDiffWarningThreshold` | `number`                                                       | `1`                          | Deposit slippage absolute percent value warning threshold, Affects styling to warn user                                                            |
@@ -127,6 +127,7 @@ UI configuration provider. Manages params to configure custom styling, component
 > | `stakingChainId`                   | `number`                                                       | `10` (Optimism)              | ChainId to be used in staking logic                                                                                                                |
 > | `termsOfUseAccepted`               | `boolean`                                                      | `true`                       | Requires user to confirm terms of use by rendering DepositTermsOfUse component before deposit action                                               |
 > | `standalone`                       | `boolean`                                                      | `true`                       | Handles token selection in SPA mode                                                                                                                |
+> | `isAllAssetsWithdrawOptionDefault` | `boolean`                                                      | `false`                      | Sets "All Assets" withdraw option by default                                                                                                       |
 > | `chainConfig`                      | `Partial<Record<ChainId, { name: string; iconPath: string }>>` | `{}`                         | Sets map of chain `name` and `iconPath`                                                                                                            |
 
 ##### actions

--- a/packages/trading-widget/src/core-kit/hooks/component/tab.ts
+++ b/packages/trading-widget/src/core-kit/hooks/component/tab.ts
@@ -6,11 +6,15 @@ import {
   useTradingPanelType,
 } from 'core-kit/hooks/state'
 import { useVaultDepositTokens } from 'core-kit/hooks/trading/deposit-v2'
+import { useCompleteWithdrawTrackedAssets } from 'core-kit/hooks/trading/withdraw-v2/complete-step'
 import type { TradingPanelType } from 'core-kit/types/trading-panel.types'
+import { useConfigContextParams } from 'trading-widget/providers/config-provider'
 
 export const useOnTradingTypeChange = () => {
   const poolConfig = useTradingPanelPoolConfig()
   const [initialDepositToken] = useVaultDepositTokens()
+  const { isAllAssetsWithdrawOptionDefault } = useConfigContextParams()
+  const { data: assets = [] } = useCompleteWithdrawTrackedAssets()
 
   const setTradingType = useTradingPanelType()[1]
   const updateSendToken = useSendTokenInput()[1]
@@ -31,16 +35,19 @@ export const useOnTradingTypeChange = () => {
   }
 
   const onWithdrawSwitch = () => {
-    const [customWithdrawToken] = poolConfig.withdrawParams.customTokens
+    const [customWithdrawToken = MULTI_ASSET_TOKEN] =
+      poolConfig.withdrawParams.customTokens
+
     updateSendToken({
       address: poolConfig.address,
       symbol: poolConfig.symbol,
       decimals: DEFAULT_PRECISION,
       value: '',
     })
-    // Set "All assets" as default withdraw option in Synthetix V3 vaults
     updateReceiveToken({
-      ...(customWithdrawToken ?? MULTI_ASSET_TOKEN),
+      ...(isAllAssetsWithdrawOptionDefault && assets.length === 0
+        ? MULTI_ASSET_TOKEN
+        : customWithdrawToken),
       value: '',
       isLoading: false,
     })

--- a/packages/trading-widget/src/trading-widget/providers/config-provider/config-provider.defaults.ts
+++ b/packages/trading-widget/src/trading-widget/providers/config-provider/config-provider.defaults.ts
@@ -32,6 +32,7 @@ export const DEFAULT_CONFIG_PARAMS: ConfigProviderParams = {
   stakingChainId: optimism.id,
   termsOfUseAccepted: true,
   standalone: true,
+  isAllAssetsWithdrawOptionDefault: false,
   chainConfig: {
     [arbitrum.id]: {
       name: 'Arbitrum',

--- a/packages/trading-widget/src/trading-widget/providers/config-provider/config-provider.types.ts
+++ b/packages/trading-widget/src/trading-widget/providers/config-provider/config-provider.types.ts
@@ -15,6 +15,7 @@ export interface ConfigProviderParams {
   termsOfUseAccepted: boolean
   standalone: boolean
   chainConfig: Partial<Record<ChainId, { name: string; iconPath: string }>>
+  isAllAssetsWithdrawOptionDefault: boolean
 }
 
 export interface ConfigProviderActions {


### PR DESCRIPTION
Added `isAllAssetsWithdrawOptionDefault` to widget config. 

When set to `true` make all assets withdraw option default