### PR TITLE
fix: remove input number arrows moz browser

### DIFF
--- a/packages/trading-widget/src/styles/index.css
+++ b/packages/trading-widget/src/styles/index.css
@@ -9,6 +9,10 @@
     -webkit-appearance: none;
     margin: 0;
   }
+
+  input[type="number"] {
+    -moz-appearance: textfield;
+  }
 }
 
 @layer components {

--- a/packages/trading-widget/src/trading-widget/components/widget/widget-input/widget-input.tsx
+++ b/packages/trading-widget/src/trading-widget/components/widget/widget-input/widget-input.tsx
@@ -66,7 +66,7 @@ export const WidgetInput: FC<WidgetInputProps> = (props) => {
               ) : (
                 <input
                   className={classNames(
-                    'dtw-appearance-none dtw-bg-transparent dtw-outline-none dtw-text-right dtw-pointer-events-none dtw-flex-1',
+                    'dtw-appearance-none dtw-bg-transparent dtw-outline-none dtw-text-right dtw-pointer-events-none dtw-flex-1 dtw-py-[1px]',
                     {
                       'dtw-text-[color:var(--panel-input-loading-content-color,var(--panel-loading-content-color))]':
                         isLoading,


### PR DESCRIPTION
Before:

<img width="417" alt="Screenshot 2024-12-12 at 20 22 28" src="https://github.com/user-attachments/assets/c8b052ca-9adf-4a61-96d6-3bd2ad6fd3fe" />

Afrer:

<img width="397" alt="Screenshot 2024-12-12 at 21 03 15" src="https://github.com/user-attachments/assets/0c111337-0610-4281-ba9d-536ca6ad5d1d" />


Also aligns trading usd amount  input height in loading state with data state.