### PR TITLE
Fix/aave asset swap data during withdraw

### DIFF
--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "license": "MIT",
   "type": "module",
   "main": "index.js",

--- a/packages/trading-widget/src/core-kit/hooks/trading/withdraw-v2/init-step/use-fetch-init-withdraw-complex-asset-data.ts
+++ b/packages/trading-widget/src/core-kit/hooks/trading/withdraw-v2/init-step/use-fetch-init-withdraw-complex-asset-data.ts
@@ -65,16 +65,19 @@ export const useFetchInitWithdrawComplexAssetData = ({
                 withdrawAmountD18,
                 slippage,
               })
-              const swapData = await fetchAaveSwapData({
-                swapParams,
-                slippage,
-              })
-              return buildAaveWithdrawAssetTransactionData({
-                assetAddress: asset,
-                swapData,
-                swapParams,
-                slippageToleranceForContractTransaction: slippageTolerance,
-              })
+
+              if (swapParams?.srcData.length) {
+                const swapData = await fetchAaveSwapData({
+                  swapParams,
+                  slippage,
+                })
+                return buildAaveWithdrawAssetTransactionData({
+                  assetAddress: asset,
+                  swapData,
+                  swapParams,
+                  slippageToleranceForContractTransaction: slippageTolerance,
+                })
+              }
             } catch (error) {
               console.error(error)
             }


### PR DESCRIPTION
Fixed handling of Aave asset swap data during the withdrawal process. If no swap is required it will return empty string as swap data.