### PR TITLE
refactor: improve updatePoolConfig method

### DIFF
--- a/packages/trading-widget/package.json
+++ b/packages/trading-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "license": "MIT",
   "type": "module",
   "main": "index.js",

--- a/packages/trading-widget/src/core-kit/hooks/state/action.test.tsx
+++ b/packages/trading-widget/src/core-kit/hooks/state/action.test.tsx
@@ -11,6 +11,7 @@ import { EstimationError } from 'core-kit/models'
 import type {
   CallbackConfig,
   PoolComposition,
+  PoolConfig,
   TradingToken,
 } from 'core-kit/types'
 import { CALLBACK_CONFIG_MOCK, TEST_ADDRESS } from 'tests/mocks'
@@ -391,15 +392,20 @@ describe('useUpdatePoolConfig', () => {
       }
     })
 
-    expect(result.current.state.poolConfigMap?.[AddressZero]?.maintenance).toBe(
+    const [address = AddressZero] = Object.keys(
+      result.current.state.poolConfigMap,
+    )
+    const poolAddress = address as PoolConfig['address']
+
+    expect(result.current.state.poolConfigMap?.[poolAddress]?.maintenance).toBe(
       undefined,
     )
     act(() => {
       result.current.setter({
-        [AddressZero]: { maintenance: true },
+        [poolAddress]: { maintenance: true },
       })
     })
-    expect(result.current.state.poolConfigMap?.[AddressZero]?.maintenance).toBe(
+    expect(result.current.state.poolConfigMap?.[poolAddress]?.maintenance).toBe(
       true,
     )
   })

--- a/packages/trading-widget/src/core-kit/providers/index.tsx
+++ b/packages/trading-widget/src/core-kit/providers/index.tsx
@@ -168,18 +168,21 @@ const createReducerWithLogger =
           ...state,
           poolConfigMap: {
             ...state.poolConfigMap,
-            ...Object.entries(action.payload).reduce<
-              TradingPanelState['poolConfigMap']
-            >(
-              (acc, [address, config]) => ({
-                ...acc,
-                [address]: {
-                  ...state.poolConfigMap?.[address as PoolConfig['address']],
-                  ...config,
-                },
-              }),
-              state.poolConfigMap,
-            ),
+            ...Object.entries(action.payload)
+              .filter(
+                ([address]) =>
+                  !!state.poolConfigMap?.[address as PoolConfig['address']],
+              )
+              .reduce<TradingPanelState['poolConfigMap']>(
+                (acc, [address, config]) => ({
+                  ...acc,
+                  [address]: {
+                    ...state.poolConfigMap?.[address as PoolConfig['address']],
+                    ...config,
+                  },
+                }),
+                state.poolConfigMap,
+              ),
           },
         }
       }


### PR DESCRIPTION
Limits `updatePoolConfig` updates by existing entities in `poolConfigMap` state.