### PR TITLE
feat: improve error key resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/core-kit/utils/__test__/error.test.ts
+++ b/src/core-kit/utils/__test__/error.test.ts
@@ -1,6 +1,9 @@
+import { TRANSACTION_ERRORS } from 'core-kit/const'
 import {
+  getErrorKey,
   getErrorMessage,
   isErrorWithMessage,
+  parseContractErrorMessage,
   validateLoggerEventParams,
 } from 'core-kit/utils/error'
 
@@ -66,5 +69,37 @@ describe('core-kit/utils/validateLoggerEventParams', () => {
     )
 
     expect(() => validateLoggerEventParams(paramsMap)).not.toThrowError()
+  })
+})
+
+describe('core-kit/utils/getErrorKey', () => {
+  it('should find best full key match', () => {
+    expect(getErrorKey('dh2', ['dh1', 'dh2', 'dh26', 'dh266'])).toEqual('dh2')
+    expect(getErrorKey('dh26', ['dh1', 'dh2', 'dh26', 'dh266'])).toEqual('dh26')
+    expect(getErrorKey('dh1', ['dh1', 'dh2', 'dh26', 'dh266'])).toEqual('dh1')
+    expect(getErrorKey('dh26')).toEqual('dh26')
+  })
+})
+
+describe('core-kit/utils/parseContractErrorMessage', () => {
+  it('should resolve error hint and title params based on dh error code', () => {
+    expect(
+      parseContractErrorMessage({
+        errorMessage: 'something wrong dh26',
+        abiErrors: [],
+      }),
+    ).toEqual(TRANSACTION_ERRORS['dh26'])
+    expect(
+      parseContractErrorMessage({
+        errorMessage: 'something dh2 wrong',
+        abiErrors: [],
+      }),
+    ).toEqual(TRANSACTION_ERRORS['dh2'])
+    expect(
+      parseContractErrorMessage({
+        errorMessage: 'something wrong: high swap slippage',
+        abiErrors: [],
+      }),
+    ).toEqual(TRANSACTION_ERRORS['high swap slippage'])
   })
 })

--- a/src/core-kit/utils/error.ts
+++ b/src/core-kit/utils/error.ts
@@ -59,8 +59,13 @@ const truncateError = (error: string, maxLength = 150) => {
   return error
 }
 
-const getErrorKey = (value: string) =>
-  TRANSACTION_ERROR_KEYS.find((key) => value.includes(key))
+export const getErrorKey = (value: string, keys = TRANSACTION_ERROR_KEYS) => {
+  const lowerValue = value.toLowerCase()
+
+  return keys
+    .sort((a, b) => b.length - a.length)
+    .find((key) => lowerValue.includes(key.toLowerCase()))
+}
 
 const getErrorParams = (value: string) =>
   TRANSACTION_ERRORS[value] ?? LIMIT_ORDER_TRANSACTION_ERRORS[value]


### PR DESCRIPTION
Enhances `getErrorKey` fn by sorting to have a chance to find full error key match.
Adds tests for `getErrorKey` and `parseContractErrorMessage` utils.