### PR TITLE
fix: implement Aave specific swap data key building

### DIFF
--- a/src/core-kit/hooks/trading/use-swaps-data-query.ts
+++ b/src/core-kit/hooks/trading/use-swaps-data-query.ts
@@ -2,35 +2,50 @@ import { type UseQueryOptions, useQuery } from '@tanstack/react-query'
 
 import type { Address } from 'viem'
 
-import { MULTI_CHAIN_SWAPPER_CONTRACT_ADDRESS } from 'core-kit/const'
 import { useGetSwapData, useTradingPanelState } from 'core-kit/hooks/state'
 import type { SwapDataRequest, SwapDataResponse } from 'core-kit/types'
+import { buildSwapDataKeyForAave } from 'core-kit/utils'
+import type {
+  AssetWithoutFromAddress,
+  SwapsDataMap,
+} from 'core-kit/utils/swap-data'
+import { fetchSwapsDataWithKey } from 'core-kit/utils/swap-data'
+
+interface FetchSwapsDataParams {
+  assets: AssetWithoutFromAddress[]
+  getSwapData: ReturnType<typeof useGetSwapData>
+  signal: AbortSignal
+}
+
+/**
+ * Aave-specific variant: during Aave swaps it is possible to have two entries
+ * with the same source asset and the same destination asset but different amounts.
+ * To avoid key collisions it includes the amount.
+ */
+export const fetchSwapsDataForAave = async ({
+  assets,
+  getSwapData,
+  signal,
+}: FetchSwapsDataParams): Promise<SwapsDataMap<string>> =>
+  fetchSwapsDataWithKey<string>({
+    assets,
+    getSwapData,
+    signal,
+    buildKey: ({ sourceAddress, amount }) =>
+      buildSwapDataKeyForAave({ sourceAddress, amount }),
+  })
 
 export const fetchSwapsData = async ({
   assets,
   getSwapData,
   signal,
-}: {
-  assets: Omit<SwapDataRequest, 'fromAddress'>[]
-  getSwapData: ReturnType<typeof useGetSwapData>
-  signal: AbortSignal
-}): Promise<Record<Address, SwapDataResponse>> =>
-  Promise.all(
-    assets.map((variables) =>
-      getSwapData({
-        signal,
-        variables: {
-          ...variables,
-          fromAddress: MULTI_CHAIN_SWAPPER_CONTRACT_ADDRESS,
-        },
-      }),
-    ),
-  ).then((data) =>
-    assets.reduce(
-      (acc, { sourceAddress }, i) => ({ ...acc, [sourceAddress]: data[i] }),
-      {},
-    ),
-  )
+}: FetchSwapsDataParams): Promise<SwapsDataMap<Address>> =>
+  fetchSwapsDataWithKey<Address>({
+    assets,
+    getSwapData,
+    signal,
+    buildKey: ({ sourceAddress }) => sourceAddress,
+  })
 
 export const useSwapsDataQuery = (
   assets: Omit<SwapDataRequest, 'fromAddress'>[],

--- a/src/core-kit/hooks/trading/withdraw-v2/init-step/use-fetch-init-withdraw-aave-swap-data.ts
+++ b/src/core-kit/hooks/trading/withdraw-v2/init-step/use-fetch-init-withdraw-aave-swap-data.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { AddressZero } from 'core-kit/const'
 import { useGetSwapData } from 'core-kit/hooks/state'
-import { fetchSwapsData } from 'core-kit/hooks/trading/use-swaps-data-query'
+import { fetchSwapsDataForAave } from 'core-kit/hooks/trading/use-swaps-data-query'
 import { useAccount } from 'core-kit/hooks/web3'
 import type {
   CalculateSwapDataParamsResponse,
@@ -37,7 +37,7 @@ export const useFetchInitWithdrawAaveSwapData = ({
         }
       })
 
-      return fetchSwapsData({
+      return fetchSwapsDataForAave({
         assets,
         getSwapData,
         signal: dummySignal,

--- a/src/core-kit/utils/aave.ts
+++ b/src/core-kit/utils/aave.ts
@@ -1,4 +1,4 @@
-import type { Address, ChainId } from 'core-kit/types'
+import type { Address, ChainId, SwapDataRequest } from 'core-kit/types'
 import { getContractAddressById, isEqualAddress } from 'core-kit/utils/web3'
 
 export interface IsLendAndBorrowAssetParams {
@@ -17,3 +17,9 @@ export const isAaveLendAndBorrowAsset = ({
 
   return isEqualAddress(address, aaveLendingPoolV3Address)
 }
+
+export const buildSwapDataKeyForAave = ({
+  sourceAddress,
+  amount,
+}: Pick<SwapDataRequest, 'sourceAddress' | 'amount'>) =>
+  `${sourceAddress}_${amount}`

--- a/src/core-kit/utils/swap-data.ts
+++ b/src/core-kit/utils/swap-data.ts
@@ -1,0 +1,38 @@
+import { MULTI_CHAIN_SWAPPER_CONTRACT_ADDRESS } from 'core-kit/const'
+import type { useGetSwapData } from 'core-kit/hooks/state'
+import type { SwapDataRequest, SwapDataResponse } from 'core-kit/types'
+
+export type AssetWithoutFromAddress = Omit<SwapDataRequest, 'fromAddress'>
+export type SwapsDataMap<T extends string> = Record<T, SwapDataResponse | null>
+
+interface FetchSwapsDataWithKeyParams<K extends string> {
+  assets: AssetWithoutFromAddress[]
+  getSwapData: ReturnType<typeof useGetSwapData>
+  signal: AbortSignal
+  buildKey: (asset: AssetWithoutFromAddress) => K
+}
+
+export const fetchSwapsDataWithKey = async <K extends string>({
+  assets,
+  getSwapData,
+  signal,
+  buildKey,
+}: FetchSwapsDataWithKeyParams<K>): Promise<SwapsDataMap<K>> => {
+  const data = await Promise.all(
+    assets.map((variables) =>
+      getSwapData({
+        signal,
+        variables: {
+          ...variables,
+          fromAddress: MULTI_CHAIN_SWAPPER_CONTRACT_ADDRESS,
+        },
+      }),
+    ),
+  )
+
+  return assets.reduce((acc, asset, i) => {
+    const key = buildKey(asset)
+    acc[key] = data[i] ?? null
+    return acc
+  }, {} as SwapsDataMap<K>)
+}

--- a/src/core-kit/utils/transaction.ts
+++ b/src/core-kit/utils/transaction.ts
@@ -7,9 +7,13 @@ import {
   ComplexWithdrawalAssetSrcDataAbiItem,
   ComplexWithdrawalDataAbiItem,
 } from 'core-kit/abi'
-import type { useSwapsDataQuery } from 'core-kit/hooks/trading/use-swaps-data-query'
+import type {
+  fetchSwapsDataForAave,
+  useSwapsDataQuery,
+} from 'core-kit/hooks/trading/use-swaps-data-query'
 import type { useCompleteWithdrawTrackedAssets } from 'core-kit/hooks/trading/withdraw-v2/complete-step/use-complete-withdraw-tracked-assets'
 import type { CalculateSwapDataParamsResponse } from 'core-kit/types'
+import { buildSwapDataKeyForAave } from 'core-kit/utils/aave'
 
 /**
  * Calculates the slippage tolerance for withdrawSafe.
@@ -114,7 +118,7 @@ export const buildAaveWithdrawAssetTransactionData = ({
 }: {
   assetAddress: Address
   swapParams: CalculateSwapDataParamsResponse | undefined
-  swapData: ReturnType<typeof useSwapsDataQuery>['data']
+  swapData: Awaited<ReturnType<typeof fetchSwapsDataForAave>>
   slippageToleranceForContractTransaction: bigint
 }) => {
   if (!swapParams) {
@@ -127,7 +131,13 @@ export const buildAaveWithdrawAssetTransactionData = ({
 
   const { srcData, dstData } = swapParams
   const srcDataToEncode = srcData.map(({ asset, amount }) => {
-    const assetSwapData = swapData?.[asset]
+    const assetSwapData =
+      swapData?.[
+        buildSwapDataKeyForAave({
+          sourceAddress: asset,
+          amount: amount.toString(),
+        })
+      ]
     return {
       asset,
       amount,


### PR DESCRIPTION
Added a custom `fetchSwapsDataForAave` function, which will be used during `initWithdrawal/withdrawSafe ` executions for fetching swap data for Aave assets. 
It uses a combination of the asset address and asset amount as a map key, which helps fix an issue when withdrawing from Pendle vaults where two similar PT tokens are lent


Can be tested here
https://github.com/dhedge/dhedge-dapp/pull/3767