### PR TITLE
Feat/configure widget responsive height

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { TradingWidget } from 'trading-widget/components'
+export { ConfigProvider } from 'trading-widget/providers/config-provider/config-provider'
 export type { ProvidersProps } from 'trading-widget/providers'
 export { TradingPanelProvider } from 'core-kit/index'
 export {
@@ -315,6 +316,7 @@ export {
   useWaitForTransactionReceipt,
   useIsBatchContractWritesSupported,
 } from 'core-kit/hooks/web3'
+export { useOnTradingTypeChange } from 'core-kit/hooks/component'
 
 export type {
   ComponentProviderProps,

--- a/src/trading-widget/components/common/layout/meta/meta.tsx
+++ b/src/trading-widget/components/common/layout/meta/meta.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react'
 
 export const Meta: FC<PropsWithChildren> = ({ children }) => (
-  <div className="dtw-flex dtw-flex-col dtw-gap-[var(--panel-meta-group-gap,var(--panel-gap))] dtw-px-[var(--panel-meta-group-px)]">
+  <div className="dtw-flex dtw-flex-col dtw-gap-[var(--panel-meta-group-gap,var(--panel-gap))] dtw-px-[var(--panel-meta-group-px)] dtw-h-full">
     {children}
   </div>
 )

--- a/src/trading-widget/components/common/layout/panel/panel.tsx
+++ b/src/trading-widget/components/common/layout/panel/panel.tsx
@@ -1,7 +1,7 @@
 import { TabPanel } from '@headlessui/react'
 import type { FC, PropsWithChildren } from 'react'
 export const Panel: FC<PropsWithChildren> = ({ children }) => (
-  <TabPanel className="dtw-pt-[var(--panel-content-pt)] dtw-pb-[var(--panel-content-pb)] dtw-px-[var(--panel-content-px)] dtw-flex dtw-flex-col dtw-gap-[var(--panel-content-gap,var(--panel-gap))]">
+  <TabPanel className="dtw-pt-[var(--panel-content-pt)] dtw-pb-[var(--panel-content-pb)] md:dtw-pb-[var(--panel-content-pb-md)] dtw-px-[var(--panel-content-px)] dtw-flex dtw-flex-col dtw-gap-[var(--panel-content-gap,var(--panel-gap))] dtw-h-full">
     {children}
   </TabPanel>
 )

--- a/src/trading-widget/components/deposit/meta/meta.tsx
+++ b/src/trading-widget/components/deposit/meta/meta.tsx
@@ -12,7 +12,7 @@ export const DepositMeta: FC<PropsWithChildren> = ({ children }) => {
     <Layout.Meta>
       <DepositTransactionOverviewDisclosure />
       {DepositMetaInfo && <DepositMetaInfo />}
-      {children}
+      <div className="dtw-mt-auto dtw-mb-0">{children}</div>
     </Layout.Meta>
   )
 }

--- a/src/trading-widget/components/widget/widget.tsx
+++ b/src/trading-widget/components/widget/widget.tsx
@@ -27,15 +27,19 @@ export const Widget: FC = () => {
   const { type, onTabChange } = useWidget()
 
   return (
-    <div className="trading-widget dtw-relative dtw-pt-3 dtw-bg-[var(--panel-background-color)] dtw-text-[color:var(--panel-content-color)] dtw-rounded-[var(--panel-radius)] dtw-overflow-hidden">
-      <TabGroup selectedIndex={TABS.indexOf(type)} onChange={onTabChange}>
+    <div className="trading-widget dtw-relative dtw-pt-3 dtw-bg-[var(--panel-background-color)] dtw-text-[color:var(--panel-content-color)] dtw-rounded-[var(--widget-radius)] md:dtw-rounded-[var(--widget-radius-md)] dtw-overflow-hidden dtw-h-full">
+      <TabGroup
+        selectedIndex={TABS.indexOf(type)}
+        onChange={onTabChange}
+        className="dtw-flex dtw-flex-col dtw-h-full"
+      >
         <WidgetTabs>
           <div className="dtw-flex dtw-gap-2 dtw-items-center dtw-justify-end">
             <ReloadSwapQuoteButton />
             <WidgetSettings tradingType={type} />
           </div>
         </WidgetTabs>
-        <TabPanels>
+        <TabPanels className="dtw-flex-1">
           <DepositTabPanel />
           <WithdrawTabPanel />
         </TabPanels>

--- a/src/trading-widget/components/withdraw/complete-step/meta/meta.tsx
+++ b/src/trading-widget/components/withdraw/complete-step/meta/meta.tsx
@@ -7,7 +7,7 @@ export const CompleteWithdrawMeta: FC<PropsWithChildren> = ({ children }) => {
   return (
     <Layout.Meta>
       <CompleteWithdrawTransactionOverviewDisclosure />
-      {children}
+      <div className="dtw-mt-auto dtw-mb-0">{children}</div>
     </Layout.Meta>
   )
 }

--- a/src/trading-widget/components/withdraw/init-step/meta/meta.tsx
+++ b/src/trading-widget/components/withdraw/init-step/meta/meta.tsx
@@ -22,7 +22,7 @@ export const InitWithdrawMeta: FC<PropsWithChildren> = ({ children }) => {
       )}
       <InitWithdrawTransactionOverviewDisclosure />
       {WithdrawMetaInfo && <WithdrawMetaInfo />}
-      {children}
+      <div className="dtw-mt-auto dtw-mb-0">{children}</div>
     </Layout.Meta>
   )
 }

--- a/src/trading-widget/providers/index.tsx
+++ b/src/trading-widget/providers/index.tsx
@@ -15,6 +15,7 @@ export interface ProvidersProps {
   config?: ConfigProviderProps['config']
   components?: ComponentProviderProps['config']
   translation?: TranslationProviderProps['config']
+  className?: string
 }
 
 export const Providers: FC<PropsWithChildren<ProvidersProps>> = ({
@@ -23,9 +24,10 @@ export const Providers: FC<PropsWithChildren<ProvidersProps>> = ({
   theme,
   components,
   translation,
+  className,
 }) => (
   <TranslationProvider config={translation}>
-    <ThemeProvider config={theme}>
+    <ThemeProvider config={theme} className={className}>
       <ConfigProvider config={config}>
         <ComponentProvider config={components}>
           <OverlayProvider>{children}</OverlayProvider>

--- a/src/trading-widget/providers/theme-provider/theme-provider.tsx
+++ b/src/trading-widget/providers/theme-provider/theme-provider.tsx
@@ -7,9 +7,11 @@ import type { ThemeProviderProps } from 'trading-widget/providers/theme-provider
 export const ThemeProvider: FC<PropsWithChildren<ThemeProviderProps>> = ({
   children,
   config,
+  className,
 }) => {
   return (
     <div
+      className={className}
       style={{
         //global-style
         // add custom CSS variables to d.ts
@@ -93,6 +95,11 @@ export const ThemeProvider: FC<PropsWithChildren<ThemeProviderProps>> = ({
           config?.global?.color?.colorBorderPrimary ??
           `var(--panel-content-color)`
         }`,
+
+        //widget
+        //widget-style
+        '--widget-radius': `${config?.component?.widget?.style?.radius ?? 'var(--panel-radius)'}`,
+        '--widget-radius-md': `${config?.component?.widget?.style?.radiusMd ?? 'var(--panel-radius)'}`,
 
         //divider
         '--panel-divider-color': `${
@@ -244,7 +251,8 @@ export const ThemeProvider: FC<PropsWithChildren<ThemeProviderProps>> = ({
           config?.component?.tabContent?.size?.pt ??
           'calc(var(--panel-spacer) * 2)'
         }`,
-        '--panel-content-pb': `calc(var(--panel-spacer) * 9)`,
+        '--panel-content-pb': `${config?.component?.tabContent?.size?.pb ?? `calc(var(--panel-spacer) * 9)`}`,
+        '--panel-content-pb-md': `${config?.component?.tabContent?.size?.pbMd ?? `var(--panel-content-pb)`}`,
         '--panel-content-px': `${
           config?.component?.tabContent?.size?.px ?? '0px'
         }`,

--- a/src/trading-widget/providers/theme-provider/theme-provider.types.ts
+++ b/src/trading-widget/providers/theme-provider/theme-provider.types.ts
@@ -61,6 +61,12 @@ export interface ThemeProviderConfigProps {
     }
   }
   component?: {
+    widget?: {
+      style?: {
+        radius?: string
+        radiusMd?: string
+      }
+    }
     notification?: {
       color?: {
         colorBg?: string
@@ -110,6 +116,7 @@ export interface ThemeProviderConfigProps {
         pt?: string
         px?: string
         pb?: string
+        pbMd?: string
         gap?: string
       }
       style?: object
@@ -284,4 +291,5 @@ export interface ThemeProviderConfigProps {
 
 export interface ThemeProviderProps {
   config?: ThemeProviderConfigProps
+  className?: string
 }


### PR DESCRIPTION
- Adds styling configuration to have an optional way to make widget's height responsive.
- Exports `useOnTradingTypeChange` hook export  to trigger widget launch from specific tab. Additionally exports  `ConfigProvider` to wrap element that gonna use `useOnTradingTypeChange` to wrap it with required provider.