### PR TITLE
Feat/export use available manager fee hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/trading-widget",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/core-kit/hooks/pool/index.ts
+++ b/src/core-kit/hooks/pool/index.ts
@@ -12,3 +12,5 @@ export { useHasSingleAssetWithdrawBlockers } from 'core-kit/hooks/pool/use-has-s
 export { usePoolDynamicExitRemainingCooldown } from 'core-kit/hooks/pool/use-pool-dynamic-exit-remaining-cooldown'
 export { useUserVaultsBalances } from 'core-kit/hooks/pool/use-user-vaults-balances'
 export { useUserVaultBalance } from 'core-kit/hooks/pool/use-user-vault-balance'
+export { useAvailableManagerFee } from 'core-kit/hooks/pool/use-available-manager-fee'
+export { useVaultSupplyCap } from 'core-kit/hooks/pool/use-vault-supply-cap'

--- a/src/core-kit/hooks/pool/use-available-manager-fee.test.ts
+++ b/src/core-kit/hooks/pool/use-available-manager-fee.test.ts
@@ -3,17 +3,12 @@ import * as wagmi from 'wagmi'
 import { DEFAULT_PRECISION, optimism } from 'core-kit/const'
 import * as multicallHooks from 'core-kit/hooks/pool/multicall'
 import { useAvailableManagerFee } from 'core-kit/hooks/pool/use-available-manager-fee'
-import * as stateHooks from 'core-kit/hooks/state'
 import { shiftBy } from 'core-kit/utils'
 import { TEST_ADDRESS } from 'tests/mocks'
 import { renderHook } from 'tests/test-utils'
 
 const toD18String = (value: string | number) =>
   shiftBy(value, DEFAULT_PRECISION)
-
-vi.mock('core-kit/hooks/state', () => ({
-  useTradingPanelPoolConfig: vi.fn(),
-}))
 
 vi.mock('core-kit/hooks/pool/multicall', () => ({
   usePoolManagerStatic: vi.fn(),
@@ -30,10 +25,6 @@ vi.mock('wagmi', async () => {
 
 describe('useAvailableManagerFee', () => {
   beforeEach(() => {
-    vi.mocked(stateHooks.useTradingPanelPoolConfig).mockReturnValue({
-      address: TEST_ADDRESS,
-      chainId: optimism.id,
-    } as unknown as ReturnType<typeof stateHooks.useTradingPanelPoolConfig>)
     vi.mocked(wagmi.useReadContract).mockReset()
   })
 
@@ -51,7 +42,9 @@ describe('useAvailableManagerFee', () => {
       } as unknown as ReturnType<typeof wagmi.useReadContract>
     })
 
-    const { result } = renderHook(() => useAvailableManagerFee())
+    const { result } = renderHook(() =>
+      useAvailableManagerFee({ address: TEST_ADDRESS, chainId: optimism.id }),
+    )
     expect(result.current.data).toBeUndefined()
   })
 
@@ -73,7 +66,9 @@ describe('useAvailableManagerFee', () => {
       } as unknown as ReturnType<typeof wagmi.useReadContract>
     })
 
-    const { result } = renderHook(() => useAvailableManagerFee())
+    const { result } = renderHook(() =>
+      useAvailableManagerFee({ address: TEST_ADDRESS, chainId: optimism.id }),
+    )
     expect(result.current.data).toBe(10)
     expect(capturedArgs.functionName).toBe('calculateAvailableManagerFee')
     expect(capturedArgs.args?.[0]).toBe(BigInt(toD18String(123.4567)))

--- a/src/core-kit/hooks/pool/use-available-manager-fee.ts
+++ b/src/core-kit/hooks/pool/use-available-manager-fee.ts
@@ -5,13 +5,22 @@ import {
   usePoolDynamic,
   usePoolManagerStatic,
 } from 'core-kit/hooks/pool/multicall'
-import { useTradingPanelPoolConfig } from 'core-kit/hooks/state'
+import type { Address, ChainId } from 'core-kit/types'
 import { normalizeNumber } from 'core-kit/utils'
 
-const select = (data: bigint) => Math.ceil(normalizeNumber(data))
+interface UseAvailableManagerFeeParams<T = number> {
+  address: Address
+  chainId: ChainId
+  select?: (data: bigint) => T
+}
 
-export const useAvailableManagerFee = () => {
-  const { address, chainId } = useTradingPanelPoolConfig()
+const defaultSelect = (data: bigint) => Math.ceil(normalizeNumber(data))
+
+export const useAvailableManagerFee = <T = number>({
+  address,
+  chainId,
+  select = defaultSelect as (data: bigint) => T,
+}: UseAvailableManagerFeeParams<T>) => {
   const { data: { totalValueD18 } = {} } = usePoolDynamic({ address, chainId })
   const { data: { maxSupplyCapD18 } = {} } = usePoolManagerStatic({
     address,

--- a/src/core-kit/hooks/pool/use-vault-supply-cap.test.ts
+++ b/src/core-kit/hooks/pool/use-vault-supply-cap.test.ts
@@ -1,0 +1,250 @@
+import { DEFAULT_PRECISION, optimism } from 'core-kit/const'
+import * as multicallHooks from 'core-kit/hooks/pool/multicall'
+import { useAvailableManagerFee } from 'core-kit/hooks/pool/use-available-manager-fee'
+import { usePoolTokenPrice } from 'core-kit/hooks/pool/use-pool-token-price'
+import { useVaultSupplyCap } from 'core-kit/hooks/pool/use-vault-supply-cap'
+import { shiftBy } from 'core-kit/utils'
+import { TEST_ADDRESS } from 'tests/mocks'
+import { renderHook } from 'tests/test-utils'
+
+vi.mock('core-kit/hooks/pool/multicall', () => ({
+  usePoolManagerStatic: vi.fn(),
+  usePoolDynamic: vi.fn(),
+}))
+
+vi.mock('core-kit/hooks/pool/use-pool-token-price', () => ({
+  usePoolTokenPrice: vi.fn(),
+}))
+
+vi.mock('core-kit/hooks/pool/use-available-manager-fee', () => ({
+  useAvailableManagerFee: vi.fn(),
+}))
+
+const toD18String = (value: string | number) =>
+  shiftBy(value, DEFAULT_PRECISION)
+
+describe('useVaultSupplyCap', () => {
+  const defaultParams = {
+    address: TEST_ADDRESS,
+    chainId: optimism.id,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null when maxSupplyCapD18 is zero', () => {
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: 0n },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(100) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 10,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when maxSupplyCapD18 is undefined', () => {
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: undefined },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(100) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 10,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toBeNull()
+  })
+
+  it('calculates vault supply correctly with basic values', () => {
+    // cap = 1000, total = 100, fee = 50, price = $2
+    // effective cap = 1000 - 50 = 950
+    // remaining = 950 - 100 = 850
+    // remaining USD = 850 * 2 = 1700
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(1000)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(100) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('2')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 50,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 100,
+      maxSupplyCapNumber: 950,
+      remainingSupplyCapNumber: 850,
+      remainingSupplyCapInUsd: 1700,
+    })
+  })
+
+  it('uses Math.ceil for totalSupplyNumber with fractional values', () => {
+    // total = 123.4567 should ceil to 124
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(1000)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(123.4567) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 0,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current?.totalSupplyNumber).toBe(124)
+  })
+
+  it('prevents negative effectiveMaxSupplyCapNumber when manager fee exceeds cap', () => {
+    // cap = 100, fee = 150 → effective should be 0, not -50
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(100)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(10) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 150,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 10,
+      maxSupplyCapNumber: 0,
+      remainingSupplyCapNumber: 0,
+      remainingSupplyCapInUsd: 0,
+    })
+  })
+
+  it('prevents negative remainingSupplyCapNumber when total exceeds effective cap', () => {
+    // cap = 200, fee = 50, total = 160
+    // effective = 150, remaining should be 0, not -10
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(200)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(160) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 50,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 160,
+      maxSupplyCapNumber: 150,
+      remainingSupplyCapNumber: 0,
+      remainingSupplyCapInUsd: 0,
+    })
+  })
+
+  it('correctly multiplies remaining cap by token price for USD value', () => {
+    // remaining = 100 tokens, price = $123.45 → $12,345
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(1000)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(800) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('123.45')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 100,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 800,
+      maxSupplyCapNumber: 900,
+      remainingSupplyCapNumber: 100,
+      remainingSupplyCapInUsd: 12345,
+    })
+  })
+
+  it('handles zero available manager fee', () => {
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(500)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(200) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 0,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 200,
+      maxSupplyCapNumber: 500,
+      remainingSupplyCapNumber: 300,
+      remainingSupplyCapInUsd: 300,
+    })
+  })
+
+  it('handles undefined available manager fee (defaults to 0)', () => {
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(500)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(200) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('1')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 200,
+      maxSupplyCapNumber: 500,
+      remainingSupplyCapNumber: 300,
+      remainingSupplyCapInUsd: 300,
+    })
+  })
+
+  it('handles decimal token prices correctly', () => {
+    // remaining = 50 tokens, price = $0.5 → $25
+    vi.mocked(multicallHooks.usePoolManagerStatic).mockReturnValue({
+      data: { maxSupplyCapD18: BigInt(toD18String(100)) },
+    } as ReturnType<typeof multicallHooks.usePoolManagerStatic>)
+    vi.mocked(multicallHooks.usePoolDynamic).mockReturnValue({
+      data: { totalSupplyD18: toD18String(50) },
+    } as ReturnType<typeof multicallHooks.usePoolDynamic>)
+    vi.mocked(usePoolTokenPrice).mockReturnValue('0.5')
+    vi.mocked(useAvailableManagerFee).mockReturnValue({
+      data: 0,
+    } as ReturnType<typeof useAvailableManagerFee>)
+
+    const { result } = renderHook(() => useVaultSupplyCap(defaultParams))
+
+    expect(result.current).toEqual({
+      totalSupplyNumber: 50,
+      maxSupplyCapNumber: 100,
+      remainingSupplyCapNumber: 50,
+      remainingSupplyCapInUsd: 25,
+    })
+  })
+})

--- a/src/core-kit/hooks/pool/use-vault-supply-cap.ts
+++ b/src/core-kit/hooks/pool/use-vault-supply-cap.ts
@@ -1,0 +1,54 @@
+import {
+  usePoolDynamic,
+  usePoolManagerStatic,
+} from 'core-kit/hooks/pool/multicall'
+import { useAvailableManagerFee } from 'core-kit/hooks/pool/use-available-manager-fee'
+import { usePoolTokenPrice } from 'core-kit/hooks/pool/use-pool-token-price'
+import type { Address, ChainId } from 'core-kit/types'
+import { normalizeNumber } from 'core-kit/utils'
+
+interface UseVaultSupplyCapParams {
+  address: Address
+  chainId: ChainId
+}
+
+// Returns null if no supply cap is set
+export const useVaultSupplyCap = ({
+  address,
+  chainId,
+}: UseVaultSupplyCapParams) => {
+  const { data: { maxSupplyCapD18 } = {} } = usePoolManagerStatic({
+    address,
+    chainId,
+  })
+  const { data: { totalSupplyD18 } = {} } = usePoolDynamic({ address, chainId })
+  const tokenPrice = usePoolTokenPrice({ address, chainId })
+  const { data: availableManagerFee = 0 } = useAvailableManagerFee({
+    address,
+    chainId,
+  })
+
+  if (!maxSupplyCapD18 || maxSupplyCapD18 === 0n) {
+    return null
+  }
+
+  const totalSupplyNumber = Math.ceil(normalizeNumber(totalSupplyD18 ?? 0))
+  const maxSupplyCapNumber = normalizeNumber(maxSupplyCapD18)
+
+  const effectiveMaxSupplyCapNumber = Math.max(
+    0,
+    maxSupplyCapNumber - availableManagerFee,
+  )
+  const remainingSupplyCapNumber = Math.max(
+    0,
+    effectiveMaxSupplyCapNumber - totalSupplyNumber,
+  )
+  const remainingSupplyCapInUsd = remainingSupplyCapNumber * Number(tokenPrice)
+
+  return {
+    totalSupplyNumber,
+    maxSupplyCapNumber: effectiveMaxSupplyCapNumber,
+    remainingSupplyCapNumber,
+    remainingSupplyCapInUsd,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,8 @@ export {
   useHasSingleAssetWithdrawBlockers,
   useUserVaultBalance,
   useUserVaultsBalances,
+  useAvailableManagerFee,
+  useVaultSupplyCap,
 } from 'core-kit/hooks/pool'
 export {
   usePoolDynamic,


### PR DESCRIPTION
https://trello.com/c/cxeDTOIQ/5720-update-available-capacity-to-consider-supply-caps-toros

Added `src/core-kit/hooks/pool/use-vault-supply-cap.ts` hook which will be used in available deposit capacity calculations